### PR TITLE
Change url project's website

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -14,7 +14,7 @@ m4_define(libmatemixer_version,
 
 AC_INIT([libmatemixer],
         [libmatemixer_version],
-        [http://www.mate-desktop.org])
+        [https://mate-desktop.org])
 
 # Before making a release, the LT_VERSION string should be modified.
 # The string is of the form C:R:A.


### PR DESCRIPTION
Now the official web site is https://mate-desktop.org/.