### PR TITLE
Use WARN_CFLAGS which are only set with --enable-compiler-warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ install:
   - ./docker-build --name ${DISTRO} --config .travis.yml --install
 
 script:
-  - ./docker-build --name ${DISTRO} --verbose --config .travis.yml --build autotools
+  - ./docker-build --name ${DISTRO} --verbose --config .travis.yml --build scripts
 
 deploy:
   - provider: script
@@ -38,6 +38,7 @@ env:
 requires:
   archlinux:
     # Useful URL: https://git.archlinux.org/svntogit/community.git/tree/libmatemixer
+    - autoconf-archive
     - gcc
     - git
     - glib2
@@ -50,6 +51,7 @@ requires:
   debian:
     # Useful URL: https://github.com/mate-desktop/debian-packages
     # Useful URL: https://salsa.debian.org/debian-mate-team/libmatemixer
+    - autoconf-archive
     - git
     - libasound2-dev
     - libglib2.0-dev
@@ -60,6 +62,7 @@ requires:
   fedora:
     # Useful URL: https://src.fedoraproject.org/cgit/rpms/libmatemixer.git
     - alsa-lib-devel
+    - autoconf-archive
     - gcc
     - git
     - make
@@ -68,6 +71,7 @@ requires:
     - redhat-rpm-config
 
   ubuntu:
+    - autoconf-archive
     - git
     - libasound2-dev
     - libglib2.0-dev
@@ -78,11 +82,28 @@ requires:
 variables:
   - CFLAGS="-Wall -Werror=format-security"
 
+build_scripts:
+  - ./autogen.sh --enable-compile-warnings=maximum
+  - make
+
 before_scripts:
+  # Debian - patch intltool-update
   - if [ ${DISTRO_NAME} == "debian" ];then
   -     curl -Ls -o debian.sh https://github.com/mate-desktop/mate-dev-scripts/raw/master/travis/debian.sh
   -     bash ./debian.sh
   - fi
+  # Install mate-common fron tarball
+  - cd ${START_DIR}
+  - '[ -f mate-common-1.23.3.tar.xz ] || curl -Ls -o mate-common-1.23.3.tar.xz http://pub.mate-desktop.org/releases/1.23/mate-common-1.23.3.tar.xz'
+  - tar xf mate-common-1.23.3.tar.xz
+  - cd mate-common-1.23.3
+  - if [ ${DISTRO_NAME} == "debian" -o ${DISTRO_NAME} == "ubuntu" ];then
+  -     ./configure --prefix=/usr --libdir=/usr/lib/x86_64-linux-gnu --libexecdir=/usr/lib/x86_64-linux-gnu
+  - else
+  -     ./configure --prefix=/usr
+  - fi
+  - make
+  - make install
 
 after_scripts:
   - make distcheck

--- a/backends/alsa/Makefile.am
+++ b/backends/alsa/Makefile.am
@@ -1,15 +1,19 @@
+NULL =
+
 backenddir = $(libdir)/libmatemixer
 
 backend_LTLIBRARIES = libmatemixer-alsa.la
 
-AM_CPPFLAGS =                                                   \
-	-Wno-unknown-pragmas                                    \
-	-I$(top_srcdir)                                         \
-	-DG_LOG_DOMAIN=\"libmatemixer-alsa\"
+AM_CPPFLAGS =							\
+	-I$(top_srcdir)						\
+	-DG_LOG_DOMAIN=\"libmatemixer-alsa\"			\
+	$(GLIB_CFLAGS)						\
+	$(ALSA_CFLAGS)						\
+	$(NULL)
 
-libmatemixer_alsa_la_CFLAGS =                                   \
-	$(GLIB_CFLAGS)                                          \
-	$(ALSA_CFLAGS)
+libmatemixer_alsa_la_CFLAGS =					\
+	$(WARN_CFLAGS)						\
+	$(NULL)
 
 libmatemixer_alsa_la_SOURCES =                                  \
 	alsa-backend.c                                          \

--- a/backends/null/Makefile.am
+++ b/backends/null/Makefile.am
@@ -1,13 +1,18 @@
+NULL =
+
 backenddir = $(libdir)/libmatemixer
 
 backend_LTLIBRARIES = libmatemixer-null.la
 
-AM_CPPFLAGS =                                                   \
-	-Wno-unknown-pragmas                                    \
-	-I$(top_srcdir)                                         \
-	-DG_LOG_DOMAIN=\"libmatemixer-null\"
+AM_CPPFLAGS =							\
+	-I$(top_srcdir)						\
+	-DG_LOG_DOMAIN=\"libmatemixer-null\"			\
+	$(GLIB_CFLAGS)						\
+	$(NULL)
 
-libmatemixer_null_la_CFLAGS = $(GLIB_CFLAGS)
+libmatemixer_null_la_CFLAGS =					\
+	$(WARN_CFLAGS)						\
+	$(NULL)
 
 libmatemixer_null_la_SOURCES =                                  \
 	null-backend.c                                          \

--- a/backends/oss/Makefile.am
+++ b/backends/oss/Makefile.am
@@ -1,15 +1,19 @@
+NULL =
+
 backenddir = $(libdir)/libmatemixer
 
 backend_LTLIBRARIES = libmatemixer-oss.la
 
-AM_CPPFLAGS =                                                   \
-	-Wno-unknown-pragmas                                    \
-	-I$(top_srcdir)                                         \
-	-DG_LOG_DOMAIN=\"libmatemixer-oss\"
+AM_CPPFLAGS =							\
+	-I$(top_srcdir)						\
+	-DG_LOG_DOMAIN=\"libmatemixer-oss\"			\
+	$(GLIB_CFLAGS)						\
+	$(OSS_CFLAGS)						\
+	$(NULL)
 
-libmatemixer_oss_la_CFLAGS =                                    \
-	$(GLIB_CFLAGS)                                          \
-	$(OSS_CFLAGS)
+libmatemixer_oss_la_CFLAGS =					\
+	$(WARN_CFLAGS)						\
+	$(NULL)
 
 libmatemixer_oss_la_SOURCES =                                   \
 	oss-common.h                                            \

--- a/backends/pulse/Makefile.am
+++ b/backends/pulse/Makefile.am
@@ -1,15 +1,19 @@
+NULL =
+
 backenddir = $(libdir)/libmatemixer
 
 backend_LTLIBRARIES = libmatemixer-pulse.la
 
-AM_CPPFLAGS =                                                   \
-	-Wno-unknown-pragmas                                    \
-	-I$(top_srcdir)                                         \
-	-DG_LOG_DOMAIN=\"libmatemixer-pulse\"
+AM_CPPFLAGS =							\
+	-I$(top_srcdir)						\
+	-DG_LOG_DOMAIN=\"libmatemixer-pulse\"			\
+	$(GLIB_CFLAGS)						\
+	$(PULSEAUDIO_CFLAGS)					\
+	$(NULL)
 
-libmatemixer_pulse_la_CFLAGS =                                  \
-	$(GLIB_CFLAGS)                                          \
-	$(PULSEAUDIO_CFLAGS)
+libmatemixer_pulse_la_CFLAGS =					\
+	$(WARN_CFLAGS)						\
+	$(NULL)
 
 libmatemixer_pulse_la_SOURCES =                                 \
 	pulse-backend.c                                         \

--- a/configure.ac
+++ b/configure.ac
@@ -51,6 +51,11 @@ m4_ifdef([AM_SILENT_RULES],
          [AM_SILENT_RULES([yes])],
          [AM_DEFAULT_VERBOSITY=1 AC_SUBST(AM_DEFAULT_VERBOSITY)])
 
+# =======================================================================
+# Compiler warnings
+# =======================================================================
+MATE_COMPILE_WARNINGS([yes])
+
 # Checks for required programs.
 AC_PROG_CC
 AM_PROG_CC_C_O
@@ -229,49 +234,6 @@ AC_SUBST(OSS_CFLAGS)
 AC_SUBST(OSS_LIBS)
 
 # =======================================================================
-# Compiler warnings
-# =======================================================================
-MATE_COMPILE_WARNINGS([maximum])
-MATE_CXX_WARNINGS
-
-# Turn on the additional warnings last, so warnings don't affect other tests.
-AC_ARG_ENABLE(more-warnings,
-        [AC_HELP_STRING([--enable-more-warnings],
-        [Maximum compiler warnings])],
-        set_more_warnings="$enableval",[
-                if test -d $srcdir/.git; then
-                        set_more_warnings=yes
-                else
-                        set_more_warnings=no
-                fi
-        ])
-
-AC_MSG_CHECKING(for more warnings)
-if test "$GCC" = "yes" -a "$set_more_warnings" != "no"; then
-        AC_MSG_RESULT(yes)
-        CFLAGS="-Wall -Wchar-subscripts -Wmissing-declarations -Wmissing-prototypes -Wnested-externs -Wpointer-arith -Wcast-align -Wsign-compare $CFLAGS"
-
-        for option in -Wno-unused-parameter -Wno-strict-aliasing -Wno-sign-compare; do
-                SAVE_CFLAGS="$CFLAGS"
-                CFLAGS="$CFLAGS $option"
-                AC_MSG_CHECKING([whether gcc understands $option])
-                AC_TRY_COMPILE([], [],
-                        has_option=yes,
-                        has_option=no,)
-                if test $has_option = no; then
-                        CFLAGS="$SAVE_CFLAGS"
-                fi
-                AC_MSG_RESULT($has_option)
-                unset has_option
-                unset SAVE_CFLAGS
-        done
-        unset option
-else
-        AC_MSG_RESULT(no)
-fi
-AC_SUBST(CFLAGS)
-
-# =======================================================================
 # Finish
 # =======================================================================
 AC_CONFIG_FILES([
@@ -302,7 +264,8 @@ echo "
         Prefix:                      ${prefix}
         Source code location:        ${srcdir}
         Compiler:                    ${CC}
-        CFLAGS:                      ${CFLAGS}
+        Compiler flags:              ${CFLAGS}
+        Warning flags:               ${WARN_CFLAGS}
 
         Build Null module:           $have_null
         Build PulseAudio module:     $have_pulseaudio

--- a/examples/Makefile.am
+++ b/examples/Makefile.am
@@ -1,10 +1,17 @@
-AM_CPPFLAGS =                                                   \
-	-I$(top_srcdir)                                         \
-	$(GLIB_CFLAGS)
+NULL =
+
+AM_CPPFLAGS =							\
+	-I$(top_srcdir)						\
+	$(GLIB_CFLAGS)						\
+	$(NULL)
 
 noinst_PROGRAMS = matemixer-monitor
 
 matemixer_monitor_SOURCES = monitor.c
+
+matemixer_monitor_CFLAGS =					\
+	$(WARN_CFLAGS)						\
+	$(NULL)
 
 matemixer_monitor_LDADD =                                       \
 	$(GLIB_LIBS)                                            \

--- a/libmatemixer/Makefile.am
+++ b/libmatemixer/Makefile.am
@@ -1,10 +1,14 @@
+NULL =
+
 lib_LTLIBRARIES = libmatemixer.la
 
-AM_CPPFLAGS =                                                   \
-	-I$(top_srcdir)                                         \
-	-I$(top_srcdir)/libmatemixer                            \
-	-DG_LOG_DOMAIN=\"libmatemixer\"                         \
-	-DLIBMATEMIXER_BACKEND_DIR=\"$(libdir)/libmatemixer\"
+AM_CPPFLAGS =							\
+	-I$(top_srcdir)						\
+	-I$(top_srcdir)/libmatemixer				\
+	-DG_LOG_DOMAIN=\"libmatemixer\"				\
+	-DLIBMATEMIXER_BACKEND_DIR=\"$(libdir)/libmatemixer\"	\
+	$(GLIB_CFLAGS)						\
+	$(NULL)
 
 libmatemixer_includedir = $(includedir)/mate-mixer/libmatemixer
 
@@ -26,7 +30,9 @@ libmatemixer_include_HEADERS =                                  \
 	matemixer-types.h                                       \
 	matemixer-version.h
 
-libmatemixer_la_CFLAGS = $(GLIB_CFLAGS)
+libmatemixer_la_CFLAGS =					\
+	$(WARN_CFLAGS)						\
+	$(NULL)
 
 libmatemixer_la_SOURCES =                                       \
 	matemixer.c                                             \


### PR DESCRIPTION
It removes --enable-more-warnings, since it is recommended to use
--enable-compile-warnings=maximum