### PR TITLE
avoid redundant redeclarations

### DIFF
--- a/backends/alsa/alsa-backend.c
+++ b/backends/alsa/alsa-backend.c
@@ -47,9 +47,6 @@ struct _AlsaBackendPrivate
     GHashTable *devices_ids;
 };
 
-static void alsa_backend_class_init     (AlsaBackendClass *klass);
-static void alsa_backend_class_finalize (AlsaBackendClass *klass);
-static void alsa_backend_init           (AlsaBackend      *alsa);
 static void alsa_backend_dispose        (GObject          *object);
 static void alsa_backend_finalize       (GObject          *object);
 

--- a/backends/alsa/alsa-device.c
+++ b/backends/alsa/alsa-device.c
@@ -69,8 +69,6 @@ enum {
 
 static guint signals[N_SIGNALS] = { 0, };
 
-static void alsa_device_class_init (AlsaDeviceClass *klass);
-static void alsa_device_init       (AlsaDevice      *device);
 static void alsa_device_dispose    (GObject         *object);
 static void alsa_device_finalize   (GObject         *object);
 

--- a/backends/alsa/alsa-stream-control.c
+++ b/backends/alsa/alsa-stream-control.c
@@ -35,9 +35,6 @@ struct _AlsaStreamControlPrivate
 
 static void alsa_element_interface_init    (AlsaElementInterface   *iface);
 
-static void alsa_stream_control_class_init (AlsaStreamControlClass *klass);
-static void alsa_stream_control_init       (AlsaStreamControl      *control);
-
 G_DEFINE_ABSTRACT_TYPE_WITH_CODE (AlsaStreamControl, alsa_stream_control,
                                   MATE_MIXER_TYPE_STREAM_CONTROL,
                                   G_ADD_PRIVATE(AlsaStreamControl)

--- a/backends/alsa/alsa-stream-input-control.c
+++ b/backends/alsa/alsa-stream-input-control.c
@@ -29,9 +29,6 @@
 #include "alsa-stream-control.h"
 #include "alsa-stream-input-control.h"
 
-static void alsa_stream_input_control_class_init (AlsaStreamInputControlClass *klass);
-static void alsa_stream_input_control_init       (AlsaStreamInputControl      *control);
-
 G_DEFINE_TYPE (AlsaStreamInputControl, alsa_stream_input_control, ALSA_TYPE_STREAM_CONTROL)
 
 static gboolean alsa_stream_input_control_load                    (AlsaStreamControl           *control);

--- a/backends/alsa/alsa-stream-output-control.c
+++ b/backends/alsa/alsa-stream-output-control.c
@@ -29,9 +29,6 @@
 #include "alsa-stream-control.h"
 #include "alsa-stream-output-control.h"
 
-static void alsa_stream_output_control_class_init (AlsaStreamOutputControlClass *klass);
-static void alsa_stream_output_control_init       (AlsaStreamOutputControl      *control);
-
 G_DEFINE_TYPE (AlsaStreamOutputControl, alsa_stream_output_control, ALSA_TYPE_STREAM_CONTROL)
 
 static gboolean alsa_stream_output_control_load                    (AlsaStreamControl           *control);

--- a/backends/alsa/alsa-stream.c
+++ b/backends/alsa/alsa-stream.c
@@ -33,8 +33,6 @@ struct _AlsaStreamPrivate
     GList *controls;
 };
 
-static void alsa_stream_class_init (AlsaStreamClass *klass);
-static void alsa_stream_init       (AlsaStream      *stream);
 static void alsa_stream_dispose    (GObject         *object);
 
 G_DEFINE_TYPE_WITH_PRIVATE (AlsaStream, alsa_stream, MATE_MIXER_TYPE_STREAM)

--- a/backends/alsa/alsa-switch-option.c
+++ b/backends/alsa/alsa-switch-option.c
@@ -27,9 +27,6 @@ struct _AlsaSwitchOptionPrivate
     guint id;
 };
 
-static void alsa_switch_option_class_init (AlsaSwitchOptionClass *klass);
-static void alsa_switch_option_init       (AlsaSwitchOption      *option);
-
 G_DEFINE_TYPE_WITH_PRIVATE (AlsaSwitchOption, alsa_switch_option, MATE_MIXER_TYPE_SWITCH_OPTION)
 
 static void

--- a/backends/alsa/alsa-switch.c
+++ b/backends/alsa/alsa-switch.c
@@ -36,8 +36,6 @@ struct _AlsaSwitchPrivate
 
 static void alsa_element_interface_init (AlsaElementInterface *iface);
 
-static void alsa_switch_class_init      (AlsaSwitchClass      *klass);
-static void alsa_switch_init            (AlsaSwitch           *swtch);
 static void alsa_switch_dispose         (GObject              *object);
 
 G_DEFINE_TYPE_WITH_CODE (AlsaSwitch, alsa_switch,

--- a/backends/alsa/alsa-toggle.c
+++ b/backends/alsa/alsa-toggle.c
@@ -36,9 +36,6 @@ struct _AlsaTogglePrivate
 
 static void alsa_element_interface_init (AlsaElementInterface *iface);
 
-static void alsa_toggle_class_init      (AlsaToggleClass      *klass);
-static void alsa_toggle_init            (AlsaToggle           *toggle);
-
 G_DEFINE_TYPE_WITH_CODE (AlsaToggle, alsa_toggle, MATE_MIXER_TYPE_STREAM_TOGGLE,
                          G_ADD_PRIVATE(AlsaToggle)
                          G_IMPLEMENT_INTERFACE (ALSA_TYPE_ELEMENT,

--- a/backends/null/null-backend.c
+++ b/backends/null/null-backend.c
@@ -26,10 +26,6 @@
 #define BACKEND_PRIORITY  0
 #define BACKEND_FLAGS     MATE_MIXER_BACKEND_NO_FLAGS
 
-static void null_backend_class_init     (NullBackendClass *klass);
-static void null_backend_class_finalize (NullBackendClass *klass);
-static void null_backend_init           (NullBackend      *null);
-
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wunused-function"
 G_DEFINE_DYNAMIC_TYPE (NullBackend, null_backend, MATE_MIXER_TYPE_BACKEND)

--- a/backends/pulse/pulse-backend.c
+++ b/backends/pulse/pulse-backend.c
@@ -114,10 +114,6 @@ struct _PulseBackendPrivate
         (g_object_steal_data (G_OBJECT (o),                             \
                               "__matemixer_pulse_hanging"))
 
-static void pulse_backend_class_init     (PulseBackendClass *klass);
-static void pulse_backend_class_finalize (PulseBackendClass *klass);
-
-static void pulse_backend_init           (PulseBackend      *pulse);
 static void pulse_backend_dispose        (GObject           *object);
 static void pulse_backend_finalize       (GObject           *object);
 

--- a/backends/pulse/pulse-connection.c
+++ b/backends/pulse/pulse-connection.c
@@ -70,8 +70,6 @@ enum {
 
 static guint signals[N_SIGNALS] = { 0, };
 
-static void pulse_connection_class_init   (PulseConnectionClass *klass);
-
 static void pulse_connection_get_property (GObject              *object,
                                            guint                 param_id,
                                            GValue               *value,
@@ -81,7 +79,6 @@ static void pulse_connection_set_property (GObject              *object,
                                            const GValue         *value,
                                            GParamSpec           *pspec);
 
-static void pulse_connection_init         (PulseConnection      *connection);
 static void pulse_connection_finalize     (GObject              *object);
 
 G_DEFINE_TYPE_WITH_PRIVATE (PulseConnection, pulse_connection, G_TYPE_OBJECT);

--- a/backends/pulse/pulse-device-profile.c
+++ b/backends/pulse/pulse-device-profile.c
@@ -33,9 +33,6 @@ struct _PulseDeviceProfilePrivate
     guint priority;
 };
 
-static void pulse_device_profile_class_init (PulseDeviceProfileClass *klass);
-static void pulse_device_profile_init       (PulseDeviceProfile      *profile);
-
 G_DEFINE_TYPE_WITH_PRIVATE (PulseDeviceProfile, pulse_device_profile, MATE_MIXER_TYPE_SWITCH_OPTION)
 
 static void

--- a/backends/pulse/pulse-device-switch.c
+++ b/backends/pulse/pulse-device-switch.c
@@ -32,8 +32,6 @@ struct _PulseDeviceSwitchPrivate
     GList *profiles;
 };
 
-static void pulse_device_switch_class_init   (PulseDeviceSwitchClass *klass);
-static void pulse_device_switch_init         (PulseDeviceSwitch      *swtch);
 static void pulse_device_switch_dispose      (GObject                *object);
 
 G_DEFINE_TYPE_WITH_PRIVATE (PulseDeviceSwitch, pulse_device_switch, MATE_MIXER_TYPE_DEVICE_SWITCH)

--- a/backends/pulse/pulse-device.c
+++ b/backends/pulse/pulse-device.c
@@ -52,8 +52,6 @@ enum {
 
 static GParamSpec *properties[N_PROPERTIES] = { NULL, };
 
-static void pulse_device_class_init   (PulseDeviceClass *klass);
-
 static void pulse_device_get_property (GObject          *object,
                                        guint             param_id,
                                        GValue           *value,
@@ -63,7 +61,6 @@ static void pulse_device_set_property (GObject          *object,
                                        const GValue     *value,
                                        GParamSpec       *pspec);
 
-static void pulse_device_init         (PulseDevice      *device);
 static void pulse_device_dispose      (GObject          *object);
 static void pulse_device_finalize     (GObject          *object);
 

--- a/backends/pulse/pulse-ext-stream.c
+++ b/backends/pulse/pulse-ext-stream.c
@@ -49,8 +49,6 @@ enum {
 
 static GParamSpec *properties[N_PROPERTIES] = { NULL, };
 
-static void pulse_ext_stream_class_init   (PulseExtStreamClass *klass);
-
 static void pulse_ext_stream_get_property (GObject             *object,
                                            guint                param_id,
                                            GValue              *value,
@@ -60,7 +58,6 @@ static void pulse_ext_stream_set_property (GObject             *object,
                                            const GValue        *value,
                                            GParamSpec          *pspec);
 
-static void pulse_ext_stream_init         (PulseExtStream      *ext);
 static void pulse_ext_stream_dispose      (GObject             *object);
 static void pulse_ext_stream_finalize     (GObject             *object);
 

--- a/backends/pulse/pulse-monitor.c
+++ b/backends/pulse/pulse-monitor.c
@@ -50,8 +50,6 @@ enum {
 
 static guint signals[N_SIGNALS] = { 0, };
 
-static void pulse_monitor_class_init   (PulseMonitorClass *klass);
-
 static void pulse_monitor_get_property (GObject           *object,
                                         guint              param_id,
                                         GValue            *value,
@@ -61,7 +59,6 @@ static void pulse_monitor_set_property (GObject           *object,
                                         const GValue      *value,
                                         GParamSpec        *pspec);
 
-static void pulse_monitor_init         (PulseMonitor      *monitor);
 static void pulse_monitor_finalize     (GObject           *object);
 
 G_DEFINE_TYPE_WITH_PRIVATE (PulseMonitor, pulse_monitor, G_TYPE_OBJECT);

--- a/backends/pulse/pulse-port-switch.c
+++ b/backends/pulse/pulse-port-switch.c
@@ -32,8 +32,6 @@ struct _PulsePortSwitchPrivate
     GList *ports;
 };
 
-static void pulse_port_switch_class_init   (PulsePortSwitchClass *klass);
-static void pulse_port_switch_init         (PulsePortSwitch         *swtch);
 static void pulse_port_switch_dispose      (GObject                 *object);
 
 G_DEFINE_ABSTRACT_TYPE_WITH_PRIVATE (PulsePortSwitch, pulse_port_switch, MATE_MIXER_TYPE_STREAM_SWITCH)

--- a/backends/pulse/pulse-port.c
+++ b/backends/pulse/pulse-port.c
@@ -32,9 +32,6 @@ struct _PulsePortPrivate
     guint priority;
 };
 
-static void pulse_port_class_init (PulsePortClass *klass);
-static void pulse_port_init       (PulsePort      *port);
-
 G_DEFINE_TYPE_WITH_PRIVATE (PulsePort, pulse_port, MATE_MIXER_TYPE_SWITCH_OPTION)
 
 static void

--- a/backends/pulse/pulse-sink-control.c
+++ b/backends/pulse/pulse-sink-control.c
@@ -28,9 +28,6 @@
 #include "pulse-sink.h"
 #include "pulse-sink-control.h"
 
-static void pulse_sink_control_class_init (PulseSinkControlClass *klass);
-static void pulse_sink_control_init       (PulseSinkControl      *control);
-
 G_DEFINE_TYPE (PulseSinkControl, pulse_sink_control, PULSE_TYPE_STREAM_CONTROL);
 
 static gboolean      pulse_sink_control_set_mute        (PulseStreamControl *psc,

--- a/backends/pulse/pulse-sink-input.c
+++ b/backends/pulse/pulse-sink-input.c
@@ -30,9 +30,6 @@
 #include "pulse-stream.h"
 #include "pulse-stream-control.h"
 
-static void pulse_sink_input_class_init (PulseSinkInputClass *klass);
-static void pulse_sink_input_init       (PulseSinkInput      *input);
-
 G_DEFINE_TYPE (PulseSinkInput, pulse_sink_input, PULSE_TYPE_STREAM_CONTROL);
 
 static guint         pulse_sink_input_get_max_volume (MateMixerStreamControl *mmsc);

--- a/backends/pulse/pulse-sink-switch.c
+++ b/backends/pulse/pulse-sink-switch.c
@@ -28,9 +28,6 @@
 #include "pulse-sink-switch.h"
 #include "pulse-stream.h"
 
-static void pulse_sink_switch_class_init (PulseSinkSwitchClass *klass);
-static void pulse_sink_switch_init       (PulseSinkSwitch      *swtch);
-
 G_DEFINE_TYPE (PulseSinkSwitch, pulse_sink_switch, PULSE_TYPE_PORT_SWITCH)
 
 static gboolean pulse_sink_switch_set_active_port (PulsePortSwitch *swtch,

--- a/backends/pulse/pulse-sink.c
+++ b/backends/pulse/pulse-sink.c
@@ -44,8 +44,6 @@ struct _PulseSinkPrivate
     PulseSinkControl *control;
 };
 
-static void pulse_sink_class_init (PulseSinkClass *klass);
-static void pulse_sink_init       (PulseSink      *sink);
 static void pulse_sink_dispose    (GObject        *object);
 static void pulse_sink_finalize   (GObject        *object);
 

--- a/backends/pulse/pulse-source-control.c
+++ b/backends/pulse/pulse-source-control.c
@@ -28,9 +28,6 @@
 #include "pulse-source.h"
 #include "pulse-source-control.h"
 
-static void pulse_source_control_class_init (PulseSourceControlClass *klass);
-static void pulse_source_control_init       (PulseSourceControl      *control);
-
 G_DEFINE_TYPE (PulseSourceControl, pulse_source_control, PULSE_TYPE_STREAM_CONTROL);
 
 static gboolean      pulse_source_control_set_mute        (PulseStreamControl *psc,

--- a/backends/pulse/pulse-source-output.c
+++ b/backends/pulse/pulse-source-output.c
@@ -30,9 +30,6 @@
 #include "pulse-stream.h"
 #include "pulse-stream-control.h"
 
-static void pulse_source_output_class_init (PulseSourceOutputClass *klass);
-static void pulse_source_output_init       (PulseSourceOutput      *output);
-
 G_DEFINE_TYPE (PulseSourceOutput, pulse_source_output, PULSE_TYPE_STREAM_CONTROL);
 
 static guint         pulse_source_output_get_max_volume (MateMixerStreamControl *mmsc);

--- a/backends/pulse/pulse-source-switch.c
+++ b/backends/pulse/pulse-source-switch.c
@@ -28,9 +28,6 @@
 #include "pulse-source-switch.h"
 #include "pulse-stream.h"
 
-static void pulse_source_switch_class_init (PulseSourceSwitchClass *klass);
-static void pulse_source_switch_init       (PulseSourceSwitch      *swtch);
-
 G_DEFINE_TYPE (PulseSourceSwitch, pulse_source_switch, PULSE_TYPE_PORT_SWITCH)
 
 static gboolean pulse_source_switch_set_active_port (PulsePortSwitch *swtch,

--- a/backends/pulse/pulse-source.c
+++ b/backends/pulse/pulse-source.c
@@ -43,8 +43,6 @@ struct _PulseSourcePrivate
     PulseSourceControl *control;
 };
 
-static void pulse_source_class_init (PulseSourceClass *klass);
-static void pulse_source_init       (PulseSource      *source);
 static void pulse_source_dispose    (GObject          *object);
 static void pulse_source_finalize   (GObject          *object);
 

--- a/backends/pulse/pulse-stream-control.c
+++ b/backends/pulse/pulse-stream-control.c
@@ -49,8 +49,6 @@ enum {
 
 static GParamSpec *properties[N_PROPERTIES] = { NULL, };
 
-static void pulse_stream_control_class_init   (PulseStreamControlClass *klass);
-
 static void pulse_stream_control_get_property (GObject                 *object,
                                                guint                    param_id,
                                                GValue                  *value,
@@ -60,7 +58,6 @@ static void pulse_stream_control_set_property (GObject                 *object,
                                                const GValue            *value,
                                                GParamSpec              *pspec);
 
-static void pulse_stream_control_init         (PulseStreamControl      *control);
 static void pulse_stream_control_dispose      (GObject                 *object);
 static void pulse_stream_control_finalize     (GObject                 *object);
 

--- a/backends/pulse/pulse-stream.c
+++ b/backends/pulse/pulse-stream.c
@@ -44,8 +44,6 @@ enum {
 
 static GParamSpec *properties[N_PROPERTIES] = { NULL, };
 
-static void pulse_stream_class_init   (PulseStreamClass *klass);
-
 static void pulse_stream_get_property (GObject          *object,
                                        guint             param_id,
                                        GValue           *value,
@@ -55,7 +53,6 @@ static void pulse_stream_set_property (GObject          *object,
                                        const GValue     *value,
                                        GParamSpec       *pspec);
 
-static void pulse_stream_init         (PulseStream      *stream);
 static void pulse_stream_dispose      (GObject          *object);
 
 G_DEFINE_ABSTRACT_TYPE_WITH_PRIVATE (PulseStream, pulse_stream, MATE_MIXER_TYPE_STREAM)

--- a/libmatemixer/matemixer-backend-module.c
+++ b/libmatemixer/matemixer-backend-module.c
@@ -41,8 +41,6 @@ enum {
     PROP_PATH
 };
 
-static void mate_mixer_backend_module_class_init   (MateMixerBackendModuleClass *klass);
-
 static void mate_mixer_backend_module_get_property (GObject                     *object,
                                                     guint                        param_id,
                                                     GValue                      *value,
@@ -52,7 +50,6 @@ static void mate_mixer_backend_module_set_property (GObject                     
                                                     const GValue                *value,
                                                     GParamSpec                  *pspec);
 
-static void mate_mixer_backend_module_init         (MateMixerBackendModule      *module);
 static void mate_mixer_backend_module_dispose      (GObject                     *object);
 static void mate_mixer_backend_module_finalize     (GObject                     *object);
 

--- a/libmatemixer/matemixer-backend.c
+++ b/libmatemixer/matemixer-backend.c
@@ -58,10 +58,6 @@ enum {
 
 static guint signals[N_SIGNALS] = { 0, };
 
-static void mate_mixer_backend_class_init   (MateMixerBackendClass *klass);
-
-static void mate_mixer_backend_init         (MateMixerBackend      *backend);
-
 static void mate_mixer_backend_get_property (GObject               *object,
                                              guint                  param_id,
                                              GValue                *value,

--- a/libmatemixer/matemixer-context.c
+++ b/libmatemixer/matemixer-context.c
@@ -108,8 +108,6 @@ enum {
 
 static guint signals[N_SIGNALS] = { 0, };
 
-static void mate_mixer_context_class_init   (MateMixerContextClass *klass);
-
 static void mate_mixer_context_get_property (GObject               *object,
                                              guint                  param_id,
                                              GValue                *value,
@@ -119,7 +117,6 @@ static void mate_mixer_context_set_property (GObject               *object,
                                              const GValue          *value,
                                              GParamSpec            *pspec);
 
-static void mate_mixer_context_init         (MateMixerContext      *context);
 static void mate_mixer_context_dispose      (GObject               *object);
 static void mate_mixer_context_finalize     (GObject               *object);
 

--- a/libmatemixer/matemixer-device-switch.c
+++ b/libmatemixer/matemixer-device-switch.c
@@ -44,8 +44,6 @@ enum {
 
 static GParamSpec *properties[N_PROPERTIES] = { NULL, };
 
-static void mate_mixer_device_switch_class_init   (MateMixerDeviceSwitchClass *klass);
-
 static void mate_mixer_device_switch_get_property (GObject                    *object,
                                                    guint                       param_id,
                                                    GValue                     *value,
@@ -54,8 +52,6 @@ static void mate_mixer_device_switch_set_property (GObject                    *o
                                                    guint                       param_id,
                                                    const GValue               *value,
                                                    GParamSpec                 *pspec);
-
-static void mate_mixer_device_switch_init         (MateMixerDeviceSwitch      *swtch);
 
 G_DEFINE_ABSTRACT_TYPE_WITH_PRIVATE (MateMixerDeviceSwitch, mate_mixer_device_switch, MATE_MIXER_TYPE_SWITCH)
 

--- a/libmatemixer/matemixer-device.c
+++ b/libmatemixer/matemixer-device.c
@@ -61,8 +61,6 @@ enum {
 
 static guint signals[N_SIGNALS] = { 0, };
 
-static void mate_mixer_device_class_init   (MateMixerDeviceClass *klass);
-
 static void mate_mixer_device_get_property (GObject              *object,
                                             guint                 param_id,
                                             GValue               *value,
@@ -72,7 +70,6 @@ static void mate_mixer_device_set_property (GObject              *object,
                                             const GValue         *value,
                                             GParamSpec           *pspec);
 
-static void mate_mixer_device_init         (MateMixerDevice      *device);
 static void mate_mixer_device_finalize     (GObject              *object);
 
 G_DEFINE_ABSTRACT_TYPE_WITH_PRIVATE (MateMixerDevice, mate_mixer_device, G_TYPE_OBJECT)

--- a/libmatemixer/matemixer-stored-control.c
+++ b/libmatemixer/matemixer-stored-control.c
@@ -36,8 +36,6 @@ enum {
 
 static GParamSpec *properties[N_PROPERTIES] = { NULL, };
 
-static void mate_mixer_stored_control_class_init   (MateMixerStoredControlClass *klass);
-
 static void mate_mixer_stored_control_get_property (GObject                     *object,
                                                     guint                        param_id,
                                                     GValue                      *value,
@@ -46,8 +44,6 @@ static void mate_mixer_stored_control_set_property (GObject                     
                                                     guint                        param_id,
                                                     const GValue                *value,
                                                     GParamSpec                  *pspec);
-
-static void mate_mixer_stored_control_init         (MateMixerStoredControl      *control);
 
 G_DEFINE_ABSTRACT_TYPE_WITH_PRIVATE (MateMixerStoredControl, mate_mixer_stored_control, MATE_MIXER_TYPE_STREAM_CONTROL)
 

--- a/libmatemixer/matemixer-stream-control.c
+++ b/libmatemixer/matemixer-stream-control.c
@@ -66,8 +66,6 @@ enum {
 
 static guint signals[N_SIGNALS] = { 0, };
 
-static void mate_mixer_stream_control_class_init   (MateMixerStreamControlClass *klass);
-
 static void mate_mixer_stream_control_get_property (GObject                     *object,
                                                     guint                        param_id,
                                                     GValue                      *value,
@@ -77,7 +75,6 @@ static void mate_mixer_stream_control_set_property (GObject                     
                                                     const GValue                *value,
                                                     GParamSpec                  *pspec);
 
-static void mate_mixer_stream_control_init         (MateMixerStreamControl      *control);
 static void mate_mixer_stream_control_finalize     (GObject                     *object);
 
 G_DEFINE_ABSTRACT_TYPE_WITH_PRIVATE (MateMixerStreamControl, mate_mixer_stream_control, G_TYPE_OBJECT)

--- a/libmatemixer/matemixer-stream-switch.c
+++ b/libmatemixer/matemixer-stream-switch.c
@@ -46,8 +46,6 @@ enum {
 
 static GParamSpec *properties[N_PROPERTIES] = { NULL, };
 
-static void mate_mixer_stream_switch_class_init   (MateMixerStreamSwitchClass *klass);
-
 static void mate_mixer_stream_switch_get_property (GObject                    *object,
                                                    guint                       param_id,
                                                    GValue                     *value,
@@ -56,8 +54,6 @@ static void mate_mixer_stream_switch_set_property (GObject                    *o
                                                    guint                       param_id,
                                                    const GValue               *value,
                                                    GParamSpec                 *pspec);
-
-static void mate_mixer_stream_switch_init         (MateMixerStreamSwitch      *swtch);
 
 G_DEFINE_ABSTRACT_TYPE_WITH_PRIVATE (MateMixerStreamSwitch, mate_mixer_stream_switch, MATE_MIXER_TYPE_SWITCH)
 

--- a/libmatemixer/matemixer-stream-toggle.c
+++ b/libmatemixer/matemixer-stream-toggle.c
@@ -45,8 +45,6 @@ enum {
 
 static GParamSpec *properties[N_PROPERTIES] = { NULL, };
 
-static void mate_mixer_stream_toggle_class_init   (MateMixerStreamToggleClass *klass);
-
 static void mate_mixer_stream_toggle_get_property (GObject                    *object,
                                                    guint                       param_id,
                                                    GValue                     *value,
@@ -56,7 +54,6 @@ static void mate_mixer_stream_toggle_set_property (GObject                    *o
                                                    const GValue               *value,
                                                    GParamSpec                 *pspec);
 
-static void mate_mixer_stream_toggle_init         (MateMixerStreamToggle      *toggle);
 static void mate_mixer_stream_toggle_dispose      (GObject                    *object);
 
 G_DEFINE_ABSTRACT_TYPE_WITH_PRIVATE (MateMixerStreamToggle, mate_mixer_stream_toggle, MATE_MIXER_TYPE_STREAM_SWITCH)

--- a/libmatemixer/matemixer-stream.c
+++ b/libmatemixer/matemixer-stream.c
@@ -64,8 +64,6 @@ enum {
 
 static guint signals[N_SIGNALS] = { 0, };
 
-static void mate_mixer_stream_class_init   (MateMixerStreamClass *klass);
-
 static void mate_mixer_stream_get_property (GObject              *object,
                                             guint                 param_id,
                                             GValue               *value,
@@ -75,7 +73,6 @@ static void mate_mixer_stream_set_property (GObject              *object,
                                             const GValue         *value,
                                             GParamSpec           *pspec);
 
-static void mate_mixer_stream_init         (MateMixerStream      *stream);
 static void mate_mixer_stream_dispose      (GObject              *object);
 static void mate_mixer_stream_finalize     (GObject              *object);
 

--- a/libmatemixer/matemixer-switch-option.c
+++ b/libmatemixer/matemixer-switch-option.c
@@ -43,8 +43,6 @@ enum {
 
 static GParamSpec *properties[N_PROPERTIES] = { NULL, };
 
-static void mate_mixer_switch_option_class_init   (MateMixerSwitchOptionClass *klass);
-
 static void mate_mixer_switch_option_get_property (GObject                    *object,
                                                    guint                       param_id,
                                                    GValue                     *value,
@@ -54,7 +52,6 @@ static void mate_mixer_switch_option_set_property (GObject                    *o
                                                    const GValue               *value,
                                                    GParamSpec                 *pspec);
 
-static void mate_mixer_switch_option_init         (MateMixerSwitchOption      *option);
 static void mate_mixer_switch_option_finalize     (GObject                    *object);
 
 G_DEFINE_TYPE_WITH_PRIVATE (MateMixerSwitchOption, mate_mixer_switch_option, G_TYPE_OBJECT)

--- a/libmatemixer/matemixer-switch.c
+++ b/libmatemixer/matemixer-switch.c
@@ -47,8 +47,6 @@ enum {
 
 static GParamSpec *properties[N_PROPERTIES] = { NULL, };
 
-static void mate_mixer_switch_class_init   (MateMixerSwitchClass *klass);
-
 static void mate_mixer_switch_get_property (GObject              *object,
                                             guint                 param_id,
                                             GValue               *value,
@@ -58,7 +56,6 @@ static void mate_mixer_switch_set_property (GObject              *object,
                                             const GValue         *value,
                                             GParamSpec           *pspec);
 
-static void mate_mixer_switch_init         (MateMixerSwitch      *swtch);
 static void mate_mixer_switch_dispose      (GObject              *object);
 static void mate_mixer_switch_finalize     (GObject              *object);
 


### PR DESCRIPTION
Fixes the warnings mentioned in .txt file:

[Wredundant-decls.txt](https://github.com/mate-desktop/libmatemixer/files/3798452/Wredundant-decls.txt)