### PR TITLE
translations: Fix 'fuzzy' warnings:

### DIFF
--- a/libmatemixer.pot
+++ b/libmatemixer.pot
@@ -3,7 +3,6 @@
 # This file is distributed under the same license as the PACKAGE package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"

--- a/po/af.po
+++ b/po/af.po
@@ -6,7 +6,6 @@
 # Translators:
 # Stefano Karapetsas <stefano@karapetsas.com>, 2018
 # 
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"

--- a/po/am.po
+++ b/po/am.po
@@ -6,7 +6,6 @@
 # Translators:
 # samson <sambelet@yahoo.com>, 2018
 # 
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"

--- a/po/ar.po
+++ b/po/ar.po
@@ -9,7 +9,6 @@
 # Abdulwahab Bah <Amb1110@gmail.com>, 2018
 # Saif Husam <saifxman10@yahoo.com>, 2018
 # 
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"

--- a/po/as.po
+++ b/po/as.po
@@ -6,7 +6,6 @@
 # Translators:
 # Stefano Karapetsas <stefano@karapetsas.com>, 2018
 # 
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"

--- a/po/ast.po
+++ b/po/ast.po
@@ -7,7 +7,6 @@
 # Stefano Karapetsas <stefano@karapetsas.com>, 2018
 # enolp <enolp@softastur.org>, 2018
 # 
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"

--- a/po/az.po
+++ b/po/az.po
@@ -6,7 +6,6 @@
 # Translators:
 # Stefano Karapetsas <stefano@karapetsas.com>, 2018
 # 
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"

--- a/po/be.po
+++ b/po/be.po
@@ -6,7 +6,6 @@
 # Translators:
 # Mihail Varantsou <meequz@gmail.com>, 2018
 # 
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"

--- a/po/bg.po
+++ b/po/bg.po
@@ -7,7 +7,6 @@
 # Любомир Василев, 2018
 # Замфир Йончев <zamfir.yonchev@gmail.com>, 2018
 # 
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"

--- a/po/bn.po
+++ b/po/bn.po
@@ -6,7 +6,6 @@
 # Translators:
 # Stefano Karapetsas <stefano@karapetsas.com>, 2018
 # 
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"

--- a/po/bn_IN.po
+++ b/po/bn_IN.po
@@ -6,7 +6,6 @@
 # Translators:
 # Stefano Karapetsas <stefano@karapetsas.com>, 2018
 # 
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"

--- a/po/br.po
+++ b/po/br.po
@@ -6,7 +6,6 @@
 # Translators:
 # Stefano Karapetsas <stefano@karapetsas.com>, 2018
 # 
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"

--- a/po/bs.po
+++ b/po/bs.po
@@ -6,7 +6,6 @@
 # Translators:
 # Sky Lion <xskylionx@gmail.com>, 2018
 # 
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"

--- a/po/ca.po
+++ b/po/ca.po
@@ -6,7 +6,6 @@
 # Translators:
 # Robert Antoni Buj Gelonch <rbuj@fedoraproject.org>, 2018
 # 
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"

--- a/po/ca@valencia.po
+++ b/po/ca@valencia.po
@@ -6,7 +6,6 @@
 # Translators:
 # Jose Alfredo Murcia Andrés <joamuran@gmail.com>, 2018
 # 
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"

--- a/po/cmn.po
+++ b/po/cmn.po
@@ -6,7 +6,6 @@
 # Translators:
 # 趙惟倫 <bluebat@member.fsf.org>, 2018
 # 
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"

--- a/po/crh.po
+++ b/po/crh.po
@@ -6,7 +6,6 @@
 # Translators:
 # Stefano Karapetsas <stefano@karapetsas.com>, 2018
 # 
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"

--- a/po/cs.po
+++ b/po/cs.po
@@ -7,7 +7,6 @@
 # Michal <sinope@seznam.cz>, 2018
 # Stanislav Kučera <inactive+kacernator@transifex.com>, 2018
 # 
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"

--- a/po/cy.po
+++ b/po/cy.po
@@ -7,7 +7,6 @@
 # Stefano Karapetsas <stefano@karapetsas.com>, 2018
 # ciaran, 2018
 # 
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"

--- a/po/da.po
+++ b/po/da.po
@@ -6,7 +6,6 @@
 # Translators:
 # Joe Hansen <joedalton2@yahoo.dk>, 2018
 # 
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"

--- a/po/de.po
+++ b/po/de.po
@@ -9,7 +9,6 @@
 # Xpistian <xpistianbecker2@web.de>, 2018
 # Julian Rüger <jr98@gmx.net>, 2018
 # 
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"

--- a/po/dz.po
+++ b/po/dz.po
@@ -6,7 +6,6 @@
 # Translators:
 # Stefano Karapetsas <stefano@karapetsas.com>, 2018
 # 
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"

--- a/po/el.po
+++ b/po/el.po
@@ -8,7 +8,6 @@
 # Panos Panagiotopoulos <panagiotopoulos@gmail.com>, 2018
 # Angelos Chraniotis <chraniotis@gmail.com>, 2018
 # 
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"

--- a/po/en_AU.po
+++ b/po/en_AU.po
@@ -6,7 +6,6 @@
 # Translators:
 # Michael Findlay <translate@cobber-linux.org>, 2018
 # 
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"

--- a/po/en_CA.po
+++ b/po/en_CA.po
@@ -6,7 +6,6 @@
 # Translators:
 # Stefano Karapetsas <stefano@karapetsas.com>, 2018
 # 
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -7,7 +7,6 @@
 # Andi Chandler <andi@gowling.com>, 2018
 # Martin Wimpress <code@flexion.org>, 2018
 # 
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"

--- a/po/eo.po
+++ b/po/eo.po
@@ -7,7 +7,6 @@
 # fenris <fenris@folksprak.org>, 2018
 # Stefano Karapetsas <stefano@karapetsas.com>, 2018
 # 
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"

--- a/po/es.po
+++ b/po/es.po
@@ -11,7 +11,6 @@
 # Emiliano Fascetti, 2018
 # Toni Estévez <toni.estevez@gmail.com>, 2019
 # 
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"

--- a/po/es_CL.po
+++ b/po/es_CL.po
@@ -6,7 +6,6 @@
 # Translators:
 # Pablo Lezaeta Reyes [pˈaβ̞lo lˌe̞θaˈeta rˈejɛ] <prflr88@gmail.com>, 2018
 # 
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"

--- a/po/es_CO.po
+++ b/po/es_CO.po
@@ -8,7 +8,6 @@
 # Jose Barakat <josebarakat@gmail.com>, 2018
 # Julian Borrero <julborre@gmail.com>, 2018
 # 
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"

--- a/po/es_MX.po
+++ b/po/es_MX.po
@@ -7,7 +7,6 @@
 # jorge becerril <jrbecster@gmail.com>, 2018
 # Luis Medina <luis.medina@sacc.com.mx>, 2018
 # 
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"

--- a/po/et.po
+++ b/po/et.po
@@ -7,7 +7,6 @@
 # Mattias Põldaru <mahfiaz@gmail.com>, 2018
 # Ivar Smolin <okul@linux.ee>, 2018
 # 
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"

--- a/po/eu.po
+++ b/po/eu.po
@@ -8,7 +8,6 @@
 # Stefano Karapetsas <stefano@karapetsas.com>, 2018
 # Egoitz Rodriguez <egoitzro@gmail.com>, 2018
 # 
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"

--- a/po/fa.po
+++ b/po/fa.po
@@ -6,7 +6,6 @@
 # Translators:
 # Mohammadreza Abdollahzadeh <morealaz@gmail.com>, 2018
 # 
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"

--- a/po/fi.po
+++ b/po/fi.po
@@ -7,7 +7,6 @@
 # Stefano Karapetsas <stefano@karapetsas.com>, 2018
 # nomen omen, 2018
 # 
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,6 @@
 # Tubuntu <tubuntu@testimonium.be>, 2018
 # yoplait <yoplait@tememe.org>, 2018
 # 
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"

--- a/po/fr_CA.po
+++ b/po/fr_CA.po
@@ -6,7 +6,6 @@
 # Translators:
 # eere leme <eerlemm@hotmail.com>, 2018
 # 
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"

--- a/po/frp.po
+++ b/po/frp.po
@@ -6,7 +6,6 @@
 # Translators:
 # Alexandre Raymond, 2018
 # 
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"

--- a/po/fur.po
+++ b/po/fur.po
@@ -6,7 +6,6 @@
 # Translators:
 # Stefano Karapetsas <stefano@karapetsas.com>, 2018
 # 
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"

--- a/po/fy.po
+++ b/po/fy.po
@@ -6,7 +6,6 @@
 # Translators:
 # Stefano Karapetsas <stefano@karapetsas.com>, 2018
 # 
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"

--- a/po/ga.po
+++ b/po/ga.po
@@ -6,7 +6,6 @@
 # Translators:
 # Stefano Karapetsas <stefano@karapetsas.com>, 2018
 # 
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"

--- a/po/gl.po
+++ b/po/gl.po
@@ -7,7 +7,6 @@
 # Stefano Karapetsas <stefano@karapetsas.com>, 2018
 # Miguel Anxo Bouzada <mbouzada@gmail.com>, 2019
 # 
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"

--- a/po/gu.po
+++ b/po/gu.po
@@ -6,7 +6,6 @@
 # Translators:
 # Stefano Karapetsas <stefano@karapetsas.com>, 2018
 # 
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"

--- a/po/he.po
+++ b/po/he.po
@@ -8,7 +8,6 @@
 # Stefano Karapetsas <stefano@karapetsas.com>, 2018
 # Edward Sawyer <saoded@gmail.com>, 2018
 # 
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"

--- a/po/hi.po
+++ b/po/hi.po
@@ -8,7 +8,6 @@
 # Sadgamaya <g.raghavan.g@gmail.com>, 2018
 # Panwar108 <caspian7pena@gmail.com>, 2018
 # 
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"

--- a/po/hr.po
+++ b/po/hr.po
@@ -6,7 +6,6 @@
 # Translators:
 # Ivica  Kolić <ikoli@yahoo.com>, 2018
 # 
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"

--- a/po/hu.po
+++ b/po/hu.po
@@ -10,7 +10,6 @@
 # Takler Tamás <taklertamas@gmail.com>, 2018
 # Falu <info@falu.me>, 2018
 # 
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"

--- a/po/hy.po
+++ b/po/hy.po
@@ -6,7 +6,6 @@
 # Translators:
 # Siranush <ss.m.95@mail.ru>, 2018
 # 
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"

--- a/po/ia.po
+++ b/po/ia.po
@@ -6,7 +6,6 @@
 # Translators:
 # Funkin, 2018
 # 
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"

--- a/po/id.po
+++ b/po/id.po
@@ -7,7 +7,6 @@
 # Ibnu Daru Aji, 2018
 # Willy Sudiarto Raharjo <willysr@slackware-id.org>, 2018
 # 
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"

--- a/po/ie.po
+++ b/po/ie.po
@@ -6,7 +6,6 @@
 # Translators:
 # Ольга Смирнова, 2019
 # 
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"

--- a/po/is.po
+++ b/po/is.po
@@ -7,7 +7,6 @@
 # Sveinn í Felli <sv1@fellsnet.is>, 2018
 # Stefano Karapetsas <stefano@karapetsas.com>, 2018
 # 
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"

--- a/po/it.po
+++ b/po/it.po
@@ -8,7 +8,6 @@
 # Dario Di Nucci <linkin88mail@gmail.com>, 2018
 # Marco Bartolucci <nap.84@live.it>, 2018
 # 
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"

--- a/po/ja.po
+++ b/po/ja.po
@@ -8,7 +8,6 @@
 # Mika Kobayashi, 2018
 # ふうせん Fu-sen. | BALLOON a.k.a. Fu-sen., 2018
 # 
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"

--- a/po/jv.po
+++ b/po/jv.po
@@ -6,7 +6,6 @@
 # Translators:
 # Ngalim Siregar <ngalim.siregar@gmail.com>, 2018
 # 
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"

--- a/po/ka.po
+++ b/po/ka.po
@@ -6,7 +6,6 @@
 # Translators:
 # Stefano Karapetsas <stefano@karapetsas.com>, 2018
 # 
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"

--- a/po/kk.po
+++ b/po/kk.po
@@ -6,7 +6,6 @@
 # Translators:
 # Baurzhan Muftakhidinov <baurthefirst@gmail.com>, 2018
 # 
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"

--- a/po/kn.po
+++ b/po/kn.po
@@ -6,7 +6,6 @@
 # Translators:
 # Stefano Karapetsas <stefano@karapetsas.com>, 2018
 # 
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"

--- a/po/ko.po
+++ b/po/ko.po
@@ -7,7 +7,6 @@
 # Seong-ho Cho <darkcircle.0426@gmail.com>, 2018
 # 박정규(Jung-Kyu Park) <bagjunggyu@gmail.com>, 2018
 # 
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"

--- a/po/ku.po
+++ b/po/ku.po
@@ -6,7 +6,6 @@
 # Translators:
 # Stefano Karapetsas <stefano@karapetsas.com>, 2018
 # 
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"

--- a/po/ku_IQ.po
+++ b/po/ku_IQ.po
@@ -6,7 +6,6 @@
 # Translators:
 # Rasti K5 <rasti.khdhr@gmail.com>, 2018
 # 
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"

--- a/po/ky.po
+++ b/po/ky.po
@@ -7,7 +7,6 @@
 # chingis, 2018
 # ballpen, 2018
 # 
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"

--- a/po/lt.po
+++ b/po/lt.po
@@ -8,7 +8,6 @@
 # Moo, 2018
 # Audrius Meskauskas, 2018
 # 
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"

--- a/po/lv.po
+++ b/po/lv.po
@@ -6,7 +6,6 @@
 # Translators:
 # Stefano Karapetsas <stefano@karapetsas.com>, 2018
 # 
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"

--- a/po/mai.po
+++ b/po/mai.po
@@ -6,7 +6,6 @@
 # Translators:
 # Stefano Karapetsas <stefano@karapetsas.com>, 2018
 # 
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"

--- a/po/mg.po
+++ b/po/mg.po
@@ -6,7 +6,6 @@
 # Translators:
 # Stefano Karapetsas <stefano@karapetsas.com>, 2018
 # 
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"

--- a/po/mk.po
+++ b/po/mk.po
@@ -7,7 +7,6 @@
 # Stefano Karapetsas <stefano@karapetsas.com>, 2018
 # exoos <mince.lesovski@gmail.com>, 2018
 # 
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"

--- a/po/ml.po
+++ b/po/ml.po
@@ -6,7 +6,6 @@
 # Translators:
 # Stefano Karapetsas <stefano@karapetsas.com>, 2018
 # 
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"

--- a/po/mn.po
+++ b/po/mn.po
@@ -6,7 +6,6 @@
 # Translators:
 # Stefano Karapetsas <stefano@karapetsas.com>, 2018
 # 
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"

--- a/po/mr.po
+++ b/po/mr.po
@@ -7,7 +7,6 @@
 # Stefano Karapetsas <stefano@karapetsas.com>, 2018
 # Vaibhav S Dalvi <vaibhav.dlv@gmail.com>, 2018
 # 
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"

--- a/po/ms.po
+++ b/po/ms.po
@@ -6,7 +6,6 @@
 # Translators:
 # abuyop <abuyop@gmail.com>, 2018
 # 
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"

--- a/po/nb.po
+++ b/po/nb.po
@@ -7,7 +7,6 @@
 # Allan Nordhøy <epost@anotheragency.no>, 2018
 # Kenneth Jenssen <kennethjenssen@yahoo.com>, 2018
 # 
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"

--- a/po/nds.po
+++ b/po/nds.po
@@ -6,7 +6,6 @@
 # Translators:
 # Stefano Karapetsas <stefano@karapetsas.com>, 2018
 # 
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"

--- a/po/ne.po
+++ b/po/ne.po
@@ -7,7 +7,6 @@
 # Stefano Karapetsas <stefano@karapetsas.com>, 2018
 # chautari <chautari@gmail.com>, 2018
 # 
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"

--- a/po/nl.po
+++ b/po/nl.po
@@ -7,7 +7,6 @@
 # Pjotr <pjotrvertaalt@gmail.com>, 2018
 # infirit <inactive+infirit@transifex.com>, 2018
 # 
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"

--- a/po/nn.po
+++ b/po/nn.po
@@ -6,7 +6,6 @@
 # Translators:
 # Stefano Karapetsas <stefano@karapetsas.com>, 2018
 # 
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"

--- a/po/nso.po
+++ b/po/nso.po
@@ -6,7 +6,6 @@
 # Translators:
 # Stefano Karapetsas <stefano@karapetsas.com>, 2018
 # 
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"

--- a/po/oc.po
+++ b/po/oc.po
@@ -6,7 +6,6 @@
 # Translators:
 # Cédric Valmary <cvalmary@yahoo.fr>, 2018
 # 
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"

--- a/po/or.po
+++ b/po/or.po
@@ -6,7 +6,6 @@
 # Translators:
 # Stefano Karapetsas <stefano@karapetsas.com>, 2018
 # 
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"

--- a/po/pa.po
+++ b/po/pa.po
@@ -6,7 +6,6 @@
 # Translators:
 # Stefano Karapetsas <stefano@karapetsas.com>, 2018
 # 
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"

--- a/po/pl.po
+++ b/po/pl.po
@@ -9,7 +9,6 @@
 # Marcin Kralka <marcink96@gmail.com>, 2018
 # Beniamin Pawlus <kupwzywcu@o2.pl>, 2018
 # 
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"

--- a/po/pms.po
+++ b/po/pms.po
@@ -6,7 +6,6 @@
 # Translators:
 # Randy Ichinose <randyichinose@gmail.com>, 2018
 # 
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"

--- a/po/ps.po
+++ b/po/ps.po
@@ -6,7 +6,6 @@
 # Translators:
 # Stefano Karapetsas <stefano@karapetsas.com>, 2018
 # 
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"

--- a/po/pt.po
+++ b/po/pt.po
@@ -9,7 +9,6 @@
 # alfalb_mansil, 2018
 # Diogo Oliveira <diogodesigns@gmail.com>, 2018
 # 
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -13,7 +13,6 @@
 # Cleber Teixeira, 2018
 # Roger Araújo <roger.rf@gmail.com>, 2018
 # 
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"

--- a/po/ro.po
+++ b/po/ro.po
@@ -8,7 +8,6 @@
 # Daniel <danny3@tutanota.com>, 2018
 # Polihron Alexandru (APoliTech) <ppolihron@gmail.com>, 2018
 # 
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"

--- a/po/ru.po
+++ b/po/ru.po
@@ -13,7 +13,6 @@
 # monsta <monsta@inbox.ru>, 2018
 # theirix <theirix@gmail.com>, 2018
 # 
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"

--- a/po/rw.po
+++ b/po/rw.po
@@ -6,7 +6,6 @@
 # Translators:
 # Stefano Karapetsas <stefano@karapetsas.com>, 2018
 # 
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"

--- a/po/si.po
+++ b/po/si.po
@@ -6,7 +6,6 @@
 # Translators:
 # Stefano Karapetsas <stefano@karapetsas.com>, 2018
 # 
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"

--- a/po/sk.po
+++ b/po/sk.po
@@ -8,7 +8,6 @@
 # Dušan Kazik <prescott66@gmail.com>, 2018
 # Tibor Kaputa <tibbbi2@gmail.com>, 2018
 # 
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"

--- a/po/sl.po
+++ b/po/sl.po
@@ -6,7 +6,6 @@
 # Translators:
 # worm <thewormhole@gmail.com>, 2018
 # 
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"

--- a/po/sq.po
+++ b/po/sq.po
@@ -9,7 +9,6 @@
 # Ardit Dani <ardit.dani@gmail.com>, 2018
 # Indrit Bashkimi <indrit.bashkimi@gmail.com>, 2018
 # 
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"

--- a/po/sr.po
+++ b/po/sr.po
@@ -6,7 +6,6 @@
 # Translators:
 # Мирослав Николић <miroslavnikolic@rocketmail.com>, 2018
 # 
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"

--- a/po/sr@latin.po
+++ b/po/sr@latin.po
@@ -6,7 +6,6 @@
 # Translators:
 # Stefano Karapetsas <stefano@karapetsas.com>, 2018
 # 
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"

--- a/po/sv.po
+++ b/po/sv.po
@@ -9,7 +9,6 @@
 # Henrik Mattsson-Mårn <h@reglage.net>, 2018
 # Marcus Larborg, 2018
 # 
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"

--- a/po/ta.po
+++ b/po/ta.po
@@ -6,7 +6,6 @@
 # Translators:
 # Stefano Karapetsas <stefano@karapetsas.com>, 2018
 # 
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"

--- a/po/te.po
+++ b/po/te.po
@@ -6,7 +6,6 @@
 # Translators:
 # Stefano Karapetsas <stefano@karapetsas.com>, 2018
 # 
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"

--- a/po/th.po
+++ b/po/th.po
@@ -6,7 +6,6 @@
 # Translators:
 # Stefano Karapetsas <stefano@karapetsas.com>, 2018
 # 
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"

--- a/po/tk.po
+++ b/po/tk.po
@@ -6,7 +6,6 @@
 # Translators:
 # Stefano Karapetsas <stefano@karapetsas.com>, 2018
 # 
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"

--- a/po/tr.po
+++ b/po/tr.po
@@ -9,7 +9,6 @@
 # Butterfly <gokhanlnx@gmail.com>, 2018
 # Kudret <kudretemre@hotmail.com.tr>, 2018
 # 
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"

--- a/po/ug.po
+++ b/po/ug.po
@@ -6,7 +6,6 @@
 # Translators:
 # Stefano Karapetsas <stefano@karapetsas.com>, 2018
 # 
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"

--- a/po/uk.po
+++ b/po/uk.po
@@ -9,7 +9,6 @@
 # Шаповалов Анатолій Романович <elrond.716.smith@gmail.com>, 2018
 # dsafsadf <heneral@gmail.com>, 2019
 # 
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"

--- a/po/ur.po
+++ b/po/ur.po
@@ -6,7 +6,6 @@
 # Translators:
 # mauron, 2018
 # 
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"

--- a/po/uz.po
+++ b/po/uz.po
@@ -6,7 +6,6 @@
 # Translators:
 # muzaffar habibullayev <muzaffarlearner@gmail.com>, 2018
 # 
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"

--- a/po/vi.po
+++ b/po/vi.po
@@ -6,7 +6,6 @@
 # Translators:
 # Stefano Karapetsas <stefano@karapetsas.com>, 2018
 # 
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"

--- a/po/wa.po
+++ b/po/wa.po
@@ -6,7 +6,6 @@
 # Translators:
 # Stefano Karapetsas <stefano@karapetsas.com>, 2018
 # 
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"

--- a/po/xh.po
+++ b/po/xh.po
@@ -6,7 +6,6 @@
 # Translators:
 # Stefano Karapetsas <stefano@karapetsas.com>, 2018
 # 
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -7,7 +7,6 @@
 # Mingcong Bai <jeffbai@aosc.xyz>, 2018
 # liushuyu011 <liushuyu011@gmail.com>, 2018
 # 
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"

--- a/po/zh_HK.po
+++ b/po/zh_HK.po
@@ -6,7 +6,6 @@
 # Translators:
 # Stefano Karapetsas <stefano@karapetsas.com>, 2018
 # 
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -6,7 +6,6 @@
 # Translators:
 # Jeff Huang <s8321414@gmail.com>, 2018
 # 
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"

--- a/po/zu.po
+++ b/po/zu.po
@@ -6,7 +6,6 @@
 # Translators:
 # Stefano Karapetsas <stefano@karapetsas.com>, 2018
 # 
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"


### PR DESCRIPTION
Fixes the warnings:
```
warning: PO file header fuzzy
warning: older versions of msgfmt will give an error on this
```

I am not sure if we need fuzzy, I don't know what means and why is there.

...and I don't know if the job can be done here, or it must be done at transifex.