### PR TITLE
makepot: remove fuzzy line

### DIFF
--- a/makepot
+++ b/makepot
@@ -3,3 +3,4 @@
 PACKAGE=libmatemixer;
 
 make -C po $PACKAGE.pot && mv po/$PACKAGE.pot .
+sed -i "/#, fuzzy/d" $PACKAGE.pot

--- a/makepot
+++ b/makepot
@@ -4,3 +4,4 @@ PACKAGE=libmatemixer;
 
 make -C po $PACKAGE.pot && mv po/$PACKAGE.pot .
 sed -i "/#, fuzzy/d" $PACKAGE.pot
+sed -i 's/charset=CHARSET/charset=UTF-8/g' $PACKAGE.pot


### PR DESCRIPTION
When we do `./makepot` , it adds the line `#, fuzzy` which give us later a lot of warnings using gettext

With this PR it removes automatically the line.