### PR TITLE
Remove warnings: ignoring #pragma clang diagnostic [-Wunknown-pragmas]

### DIFF
--- a/backends/alsa/alsa-backend.c
+++ b/backends/alsa/alsa-backend.c
@@ -50,14 +50,11 @@ struct _AlsaBackendPrivate
 static void alsa_backend_dispose        (GObject          *object);
 static void alsa_backend_finalize       (GObject          *object);
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunused-function"
 G_DEFINE_DYNAMIC_TYPE_EXTENDED (AlsaBackend,
                                 alsa_backend,
                                 MATE_MIXER_TYPE_BACKEND,
                                 0,
                                 G_ADD_PRIVATE_DYNAMIC(AlsaBackend))
-#pragma clang diagnostic pop
 
 static gboolean     alsa_backend_open            (MateMixerBackend *backend);
 static void         alsa_backend_close           (MateMixerBackend *backend);

--- a/backends/null/null-backend.c
+++ b/backends/null/null-backend.c
@@ -26,10 +26,7 @@
 #define BACKEND_PRIORITY  0
 #define BACKEND_FLAGS     MATE_MIXER_BACKEND_NO_FLAGS
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunused-function"
 G_DEFINE_DYNAMIC_TYPE (NullBackend, null_backend, MATE_MIXER_TYPE_BACKEND)
-#pragma clang diagnostic pop
 
 static gboolean null_backend_open (MateMixerBackend *backend);
 

--- a/backends/pulse/pulse-backend.c
+++ b/backends/pulse/pulse-backend.c
@@ -117,10 +117,7 @@ struct _PulseBackendPrivate
 static void pulse_backend_dispose        (GObject           *object);
 static void pulse_backend_finalize       (GObject           *object);
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunused-function"
 G_DEFINE_DYNAMIC_TYPE_EXTENDED (PulseBackend, pulse_backend, MATE_MIXER_TYPE_BACKEND, 0, G_ADD_PRIVATE_DYNAMIC(PulseBackend))
-#pragma clang diagnostic pop
 
 static gboolean         pulse_backend_open                      (MateMixerBackend *backend);
 static void             pulse_backend_close                     (MateMixerBackend *backend);


### PR DESCRIPTION
```
null-backend.c:29: warning: ignoring #pragma clang diagnostic [-Wunknown-pragmas]
   29 | #pragma clang diagnostic push
      |
null-backend.c:30: warning: ignoring #pragma clang diagnostic [-Wunknown-pragmas]
   30 | #pragma clang diagnostic ignored "-Wunused-function"
      |
null-backend.c:32: warning: ignoring #pragma clang diagnostic [-Wunknown-pragmas]
   32 | #pragma clang diagnostic pop
      |
```
```
pulse-backend.c:120: warning: ignoring #pragma clang diagnostic [-Wunknown-pragmas]
  120 | #pragma clang diagnostic push
      |
pulse-backend.c:121: warning: ignoring #pragma clang diagnostic [-Wunknown-pragmas]
  121 | #pragma clang diagnostic ignored "-Wunused-function"
      |
pulse-backend.c:123: warning: ignoring #pragma clang diagnostic [-Wunknown-pragmas]
  123 | #pragma clang diagnostic pop
      |
```
```
alsa-backend.c:53: warning: ignoring #pragma clang diagnostic [-Wunknown-pragmas]
   53 | #pragma clang diagnostic push
      |
alsa-backend.c:54: warning: ignoring #pragma clang diagnostic [-Wunknown-pragmas]
   54 | #pragma clang diagnostic ignored "-Wunused-function"
      |
alsa-backend.c:60: warning: ignoring #pragma clang diagnostic [-Wunknown-pragmas]
   60 | #pragma clang diagnostic pop
      |
```
