### PR TITLE
Fix initialization of the OSS backend

### DIFF
--- a/backends/oss/oss-backend.c
+++ b/backends/oss/oss-backend.c
@@ -61,7 +61,7 @@ static void oss_backend_finalize       (GObject         *object);
 
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wunused-function"
-G_DEFINE_DYNAMIC_TYPE_EXTENDED (OssBackend, oss_backend, MATE_MIXER_TYPE_BACKEND, 0, G_ADD_PRIVATE (OssBackend))
+G_DEFINE_DYNAMIC_TYPE_EXTENDED (OssBackend, oss_backend, MATE_MIXER_TYPE_BACKEND, 0, G_ADD_PRIVATE_DYNAMIC (OssBackend))
 #pragma clang diagnostic pop
 
 static gboolean     oss_backend_open             (MateMixerBackend *backend);


### PR DESCRIPTION
The OSS backend doesn't load correctly since [this commit](https://github.com/mate-desktop/libmatemixer/commit/ceedb3408e9f12f1b36ad98218fee69960eb47e8) because it uses the wrong macro to add private data to a dynamic type. The bug is obvious if you compare the commit with the same changes applied to the [alsa](https://github.com/mate-desktop/libmatemixer/commit/ead1fde223a89a5157e936d23b3bbc5d77260167) and [pulse](https://github.com/mate-desktop/libmatemixer/commit/498b37841f36c86a27b75b97a4fc22053da94ffa) backends.

With the wrong macro, the private struct is not allocated correctly, which causes memory errors and crashes as shown in #28.

This patch closes #28 and I think may deserve a point release of libmatemixer as the bug likely affects most BSD users.