### PR TITLE
build: set GETTEXT_PACKAGE=AC_PACKAGE_NAME

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -72,7 +72,7 @@ LT_INIT
 # Gettext
 # =======================================================================
 
-GETTEXT_PACKAGE=libmatemixer
+GETTEXT_PACKAGE=AC_PACKAGE_NAME
 AC_SUBST(GETTEXT_PACKAGE)
 AC_DEFINE_UNQUOTED(GETTEXT_PACKAGE, "$GETTEXT_PACKAGE", [Gettext Package])
 


### PR DESCRIPTION
Test:
```
$ ./autogen.sh --prefix=/usr && grep GETTEXT_PACKAGE config.h
<cut>
#define GETTEXT_PACKAGE "libmatemixer"
```