### PR TITLE
build: show configure summary using a pretty format

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -283,19 +283,19 @@ po/Makefile.in
 AC_OUTPUT
 
 echo "
+Configure summary:
 
-                    ${PACKAGE} ${VERSION}
-                    ============
+    ${PACKAGE_STRING}
+    `echo $PACKAGE_STRING | sed "s/./=/g"`
 
+    Prefix ........................: ${prefix}
+    Source code location ..........: ${srcdir}
+    Compiler ......................: ${CC}
+    Compiler flags ................: ${CFLAGS}
+    Warning flags .................: ${WARN_CFLAGS}
 
-        Prefix:                      ${prefix}
-        Source code location:        ${srcdir}
-        Compiler:                    ${CC}
-        Compiler flags:              ${CFLAGS}
-        Warning flags:               ${WARN_CFLAGS}
-
-        Build Null module:           $have_null
-        Build PulseAudio module:     $have_pulseaudio
-        Build ALSA module:           $have_alsa (udev: $have_udev)
-        Build OSS module:            $have_oss
+    Build Null module .............: $have_null
+    Build PulseAudio module .......: $have_pulseaudio
+    Build ALSA module .............: $have_alsa (udev: $have_udev)
+    Build OSS module ..............: $have_oss
 "


### PR DESCRIPTION
sample output:
```
Configure summary:

    libmatemixer 1.26.0
    ===================

    Prefix ........................: /usr
    Source code location ..........: .
    Compiler ......................: gcc
    Compiler flags ................: -g -O2
    Warning flags .................: -Wall -Wmissing-prototypes

    Build Null module .............: yes
    Build PulseAudio module .......: yes
    Build ALSA module .............: yes (udev: yes)
    Build OSS module ..............: no

Now type `make' to compile libmatemixer
```