### PR TITLE
backends: Add missing dependencies

### DIFF
--- a/backends/alsa/Makefile.am
+++ b/backends/alsa/Makefile.am
@@ -43,6 +43,7 @@ libmatemixer_alsa_la_SOURCES =                                  \
 	alsa-types.h
 
 libmatemixer_alsa_la_LIBADD =                                   \
+	$(top_builddir)/libmatemixer/libmatemixer.la            \
 	$(GLIB_LIBS)                                            \
 	$(UDEV_LIBS)						\
 	$(ALSA_LIBS)

--- a/backends/null/Makefile.am
+++ b/backends/null/Makefile.am
@@ -18,7 +18,9 @@ libmatemixer_null_la_SOURCES =                                  \
 	null-backend.c                                          \
 	null-backend.h
 
-libmatemixer_null_la_LIBADD = $(GLIB_LIBS)
+libmatemixer_null_la_LIBADD =                                   \
+	$(top_builddir)/libmatemixer/libmatemixer.la            \
+	$(GLIB_LIBS)
 
 libmatemixer_null_la_LDFLAGS =                                  \
 	-avoid-version                                          \

--- a/backends/oss/Makefile.am
+++ b/backends/oss/Makefile.am
@@ -32,6 +32,7 @@ libmatemixer_oss_la_SOURCES =                                   \
 	oss-types.h
 
 libmatemixer_oss_la_LIBADD =                                    \
+	$(top_builddir)/libmatemixer/libmatemixer.la            \
 	$(GLIB_LIBS)                                            \
 	$(OSS_LIBS)
 

--- a/backends/pulse/Makefile.am
+++ b/backends/pulse/Makefile.am
@@ -62,6 +62,7 @@ libmatemixer_pulse_la_SOURCES =                                 \
 	pulse-types.h
 
 libmatemixer_pulse_la_LIBADD =                                  \
+	$(top_builddir)/libmatemixer/libmatemixer.la            \
 	$(GLIB_LIBS)                                            \
 	$(PULSEAUDIO_LIBS)
 


### PR DESCRIPTION
When building the backends with slibtool they will fail with undefined references to `libmatemixer.la`. This is because they use -no-undefined which slibtool explicitly supports while GNU libtool will silently ignore it.

Gentoo Bug: https://bugs.gentoo.org/785232