### PR TITLE
pulse: Don't crash on failure to retrieve server info

### DIFF
--- a/backends/pulse/pulse-connection.c
+++ b/backends/pulse/pulse-connection.c
@@ -1467,6 +1467,11 @@ pulse_server_info_cb (pa_context           *c,
 {
     PulseConnection *connection;
 
+    if (! info) {
+        g_warning ("Failed to get PulseAudio server information: %s", pa_strerror (pa_context_errno (c)));
+        return;
+    }
+
     connection = PULSE_CONNECTION (userdata);
 
     g_signal_emit (G_OBJECT (connection),


### PR DESCRIPTION
Although the documentation isn't very verbose, [pactl handles this case like this](https://sources.debian.org/src/pulseaudio/17.0+dfsg1-2/src/utils/pactl.c/?hl=229#L229), so a `NULL` info is likely a valid result of this call upon failure.

Most of the code is actually just copied over from pactl.c itself, there wasn't much more to it.

Part-of: mate-desktop/mate-media#159

---

I'm not entirely sure what should really happen when this error occurs, potentially the connection should be severed or something, but at least this will prevent a crash dereferencing the NULL `info` pointer as seen in https://github.com/mate-desktop/mate-media/issues/159#issuecomment-2634479587